### PR TITLE
Remove demo link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ Gatsby plugin for react-native-web
 
 Share components between your React Native mobile app and your Gatsby static website.
 
-Check the [online demo](https://gatsby-rnw.now.sh/) and its [code](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-react-native-web)
-
-![online demo screenshot](https://pbs.twimg.com/media/Db4PTPKW0AAVPl8.jpg)
-
 # Install
 
 `npm install --save gatsby-plugin-react-native-web`


### PR DESCRIPTION
A demo was removed from gatsby repo. https://github.com/gatsbyjs/gatsby/pull/7095