### PR TITLE
fix: add `.web.*` webpack module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "babel-preset-latest": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "babel-plugin-react-native-web": "^0.6.1"
+    "babel-plugin-react-native-web": "^0.6.1",
+    "webpack-merge": "^4.1.5"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -16,7 +16,7 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
     '.ts',
     '.web.tsx',
     '.tsx',
-    'web.jsx',
+    '.web.jsx',
     '.jsx',
     '.web.wasm',
     '.wasm',

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -4,7 +4,27 @@ exports.onCreateBabelConfig = ({ actions }) => {
   })
 }
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
+  const config = getConfig()
+
+  config.resolve.extensions = [
+    '.web.mjs',
+    '.mjs',
+    '.web.js',
+    '.js',
+    '.web.ts',
+    '.ts',
+    '.web.tsx',
+    '.tsx',
+    'web.jsx',
+    '.jsx',
+    '.web.wasm',
+    '.wasm',
+    '.json',
+  ]
+
+  actions.replaceWebpackConfig(config)
+
   actions.setWebpackConfig({
     resolve: {
       alias: {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -5,31 +5,31 @@ exports.onCreateBabelConfig = ({ actions }) => {
 }
 
 exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
-  const config = getConfig()
+  const originalWebpackConfig = getConfig()
 
-  config.resolve.extensions = [
-    '.web.mjs',
-    '.mjs',
-    '.web.js',
-    '.js',
-    '.web.ts',
-    '.ts',
-    '.web.tsx',
-    '.tsx',
-    '.web.jsx',
-    '.jsx',
-    '.web.wasm',
-    '.wasm',
-    '.json',
-  ]
-
-  actions.replaceWebpackConfig(config)
-
-  actions.setWebpackConfig({
+  const reactNativeWebConfig = {
     resolve: {
+      extensions: [
+        '.web.mjs',
+        '.mjs',
+        '.web.js',
+        '.js',
+        '.web.ts',
+        '.ts',
+        '.web.tsx',
+        '.tsx',
+        '.web.jsx',
+        '.jsx',
+        '.web.wasm',
+        '.wasm',
+      ],
       alias: {
         'react-native': 'react-native-web',
       },
     },
-  })
+  }
+
+  const newConfig = merge(reactNativeWebConfig, originalWebpackConfig)
+
+  actions.replaceWebpackConfig(newConfig)
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,3 +1,5 @@
+const merge = require('webpack-merge')
+
 exports.onCreateBabelConfig = ({ actions }) => {
   actions.setBabelPlugin({
     name: `babel-plugin-react-native-web`,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -13,17 +13,12 @@ exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
     resolve: {
       extensions: [
         '.web.mjs',
-        '.mjs',
         '.web.js',
-        '.js',
-        '.web.ts',
-        '.ts',
-        '.web.tsx',
-        '.tsx',
         '.web.jsx',
-        '.jsx',
         '.web.wasm',
-        '.wasm',
+        '.web.json',
+        '.web.ts',
+        '.web.tsx',
       ],
       alias: {
         'react-native': 'react-native-web',


### PR DESCRIPTION
`.web.{js,jsx,...}` currently are not taking precedence in webpack's module resolution.

this PR adds this feature, because sometimes we want to use web-specific component under the same name. e.g.:
`Modal.js` and `Modal.web.js` <- should use Modal.web.js

I have tested and confirm that it works on a Gatsby project